### PR TITLE
Add macOS Intel packaging config

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
         "start": "electron .",
         "mcp": "node src/mcp-server-v3.js",
         "cli": "node cli/proxima-cli.cjs",
+        "dist": "electron-builder --mac --x64",
+        "dist:mac": "electron-builder --mac --x64",
+        "dist:dmg": "electron-builder --mac dmg --x64",
         "build": "electron-builder --win --x64",
         "build:installer": "electron-builder --win --x64 -c.win.target=nsis"
     },
@@ -47,6 +50,20 @@
             "cli/**/*",
             "node_modules/**/*"
         ],
+        "mac": {
+            "target": [
+                {
+                    "target": "zip",
+                    "arch": [
+                        "x64"
+                    ]
+                }
+            ],
+            "icon": "assets/proxima-icon.png",
+            "category": "public.app-category.developer-tools",
+            "identity": null,
+            "artifactName": "${productName}-Mac-Intel-${version}.${ext}"
+        },
         "win": {
             "target": [
                 {


### PR DESCRIPTION
## Summary

Adds macOS x64 packaging support via electron-builder so Proxima can be packaged for Intel Macs.

## Changes

- Adds `dist` and `dist:mac` scripts for macOS x64 builds.
- Adds `dist:dmg` for generating a macOS DMG package.
- Adds macOS electron-builder config using the existing `assets/proxima-icon.png`.
- Sets the macOS app category to Developer Tools.
- Disables local signing by setting `identity` to `null`.

## Testing

Tested locally on Intel macOS:

```bash
npm run dist
```

Verified that the generated app binary is x86_64:

```bash
file dist/mac/Proxima.app/Contents/MacOS/Proxima
```

Result:

```text
dist/mac/Proxima.app/Contents/MacOS/Proxima: Mach-O 64-bit executable x86_64
```

Closes #23
