### PR TITLE
Feature/session aware routing

### DIFF
--- a/electron/main-v2.cjs
+++ b/electron/main-v2.cjs
@@ -507,16 +507,16 @@ async function handleMCPRequest(request) {
 
                         const uploadResult = await uploadFileToProvider(provider, data.filePath);
                         await sleep(1000); // Wait for file to attach
-                        const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false);
+                        const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false, data.context || null);
                         return { success: true, provider, result, fileUploaded: uploadResult };
                     } catch (fileErr) {
                         console.error('[MCP] File upload failed:', fileErr.message);
                         // Still send message even if file upload fails
-                        const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false);
+                        const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false, data.context || null);
                         return { success: true, provider, result, fileError: fileErr.message };
                     }
                 } else {
-                    const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false);
+                    const result = await sendMessageToProvider(provider, data.message, data.forceDOM || false, data.context || null);
                     return { success: true, provider, result };
                 }
 
@@ -729,7 +729,7 @@ async function handleMCPRequest(request) {
 
 // Provider-Specific Interaction Functions
 
-async function sendMessageToProvider(provider, message, forceDOM = false) {
+async function sendMessageToProvider(provider, message, forceDOM = false, context = null) {
     const webContents = browserManager.getWebContents(provider);
     if (!webContents) {
         throw new Error(`Provider ${provider} not initialized`);
@@ -739,8 +739,14 @@ async function sendMessageToProvider(provider, message, forceDOM = false) {
     if (!forceDOM) {
         try {
             console.log(`[${provider}] Trying API-first approach...`);
-            const apiResponse = await providerAPI.sendViaAPI(provider, webContents, message);
-            if (apiResponse && apiResponse.length > 0) {
+            const apiResponse = await providerAPI.sendViaAPI(provider, webContents, message, context);
+            if (apiResponse && apiResponse.text && apiResponse.text.length > 0) {
+                console.log(`[${provider}] \u2714 API response captured (${apiResponse.text.length} chars)`);
+                _apiResponseCache[provider] = apiResponse.text;
+                return { response: apiResponse.text, context: apiResponse.context };
+            }
+            // Backward compat: handle old string format
+            if (apiResponse && typeof apiResponse === 'string' && apiResponse.length > 0) {
                 console.log(`[${provider}] \u2714 API response captured (${apiResponse.length} chars)`);
                 _apiResponseCache[provider] = apiResponse;
                 return { response: apiResponse };

--- a/electron/provider-api.cjs
+++ b/electron/provider-api.cjs
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const sessionStore = require('./session-store.cjs');
 
 
 const _scripts = {};
@@ -89,9 +90,10 @@ async function ensureAPI(provider, webContents) {
  * @param {string} provider
  * @param {object} webContents - Electron webContents
  * @param {string} message
- * @returns {string|null} Response text, or null if unavailable
+ * @param {object|null} context - Conversation context for session routing
+ * @returns {{ text: string, context: object|null }|null} Response object, or null if unavailable
  */
-async function sendViaAPI(provider, webContents, message) {
+async function sendViaAPI(provider, webContents, message, context) {
     // Ensure API is injected
     const ready = await ensureAPI(provider, webContents);
     if (!ready) {
@@ -109,22 +111,34 @@ async function sendViaAPI(provider, webContents, message) {
     const apiObj = sendMap[provider];
     if (!apiObj) return null;
 
-    // Escape message for safe JS injection
+    // Escape message and context for safe JS injection
     const escapedMessage = JSON.stringify(message);
+    const escapedContext = JSON.stringify(context || null);
 
     try {
         console.log(`[ProviderAPI] Sending via ${provider} API...`);
         const startTime = Date.now();
 
         const result = await webContents.executeJavaScript(
-            `window.${apiObj}.send(${escapedMessage})`
+            `window.${apiObj}.send(${escapedMessage}, ${escapedContext})`
         );
 
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        const charCount = result ? result.length : 0;
-        console.log(`[ProviderAPI] ✔ ${provider} API response: ${charCount} chars in ${elapsed}s`);
 
-        return result || null;
+        // Backward compat: if result is a plain string (old engine), wrap it
+        if (typeof result === 'string') {
+            const charCount = result.length;
+            console.log(`[ProviderAPI] ✔ ${provider} API response: ${charCount} chars in ${elapsed}s`);
+            return { text: result, context: null };
+        }
+
+        if (result && typeof result === 'object' && result.text !== undefined) {
+            const charCount = result.text ? result.text.length : 0;
+            console.log(`[ProviderAPI] ✔ ${provider} API response: ${charCount} chars in ${elapsed}s`);
+            return { text: result.text, context: result.context || null };
+        }
+
+        return null;
     } catch (e) {
         console.error(`[ProviderAPI] ✘ ${provider} API error:`, e.message);
         return null;
@@ -166,6 +180,9 @@ async function resetConversation(provider, webContentsGetter) {
                 `if (window.${apiObj} && window.${apiObj}.newConversation) { window.${apiObj}.newConversation(); }`
             );
             console.log(`[ProviderAPI] ✔ Reset conversation for ${p}`);
+
+            sessionStore.clearProvider(p);
+            console.log(`[ProviderAPI] ✔ Cleared session store for ${p}`);
         } catch (e) {
             console.error(`[ProviderAPI] ✘ Failed to reset conversation for ${p}:`, e.message);
         }

--- a/electron/providers/chatgpt-engine.js
+++ b/electron/providers/chatgpt-engine.js
@@ -257,7 +257,11 @@
 
     // ─── Send Message ───────────────────────────────
 
-    async function send(message) {
+    async function send(message, context) {
+        // Determine which conversation state to use: provided context or global state
+        var activeConversationId = (context && context.conversationId) || _conversationId;
+        var activeParentMessageId = (context && context.parentMessageId) || _parentMessageId;
+
         var token = await _getToken();
 
         // OAI-Device-Id header required for API auth
@@ -293,7 +297,7 @@
             }],
             model: 'auto',
 
-            parent_message_id: _parentMessageId || crypto.randomUUID(),
+            parent_message_id: activeParentMessageId || crypto.randomUUID(),
             timezone_offset_min: new Date().getTimezoneOffset(),
             history_and_training_disabled: false,
             conversation_mode: { kind: 'primary_assistant' },
@@ -304,9 +308,9 @@
         };
 
 
-        if (_conversationId) {
-            payload.conversation_id = _conversationId;
-            console.log('[Proxima ChatGPT] Continuing conversation:', _conversationId);
+        if (activeConversationId) {
+            payload.conversation_id = activeConversationId;
+            console.log('[Proxima ChatGPT] Continuing conversation:', activeConversationId);
         } else {
             console.log('[Proxima ChatGPT] Starting new conversation');
         }
@@ -342,7 +346,7 @@
             }
             var result = await _parseSSEStream(res);
             clearTimeout(retryTimeoutId);
-            return result;
+            return { text: result, context: { conversationId: _conversationId, parentMessageId: _parentMessageId } };
         }
 
         if (!res.ok) {
@@ -360,7 +364,7 @@
 
         var result = await _parseSSEStream(res);
         clearTimeout(timeoutId);
-        return result;
+        return { text: result, context: { conversationId: _conversationId, parentMessageId: _parentMessageId } };
     }
 
 

--- a/electron/providers/chatgpt-engine.js
+++ b/electron/providers/chatgpt-engine.js
@@ -259,8 +259,10 @@
 
     async function send(message, context) {
         // Determine which conversation state to use: provided context or global state
-        var activeConversationId = (context && context.conversationId) || _conversationId;
-        var activeParentMessageId = (context && context.parentMessageId) || _parentMessageId;
+        // context.__new means "start a new conversation, don't reuse global state"
+        var isNewSession = context && context.__new;
+        var activeConversationId = isNewSession ? null : ((context && context.conversationId) || _conversationId);
+        var activeParentMessageId = isNewSession ? null : ((context && context.parentMessageId) || _parentMessageId);
 
         var token = await _getToken();
 

--- a/electron/providers/claude-engine.js
+++ b/electron/providers/claude-engine.js
@@ -93,7 +93,9 @@
         var orgId = await _getOrgId();
 
         // Determine which convId to use: provided context or global state
-        var activeConvId = (context && context.convId) || _convId;
+        // context.__new means "start a new conversation, don't reuse global state"
+        var isNewSession = context && context.__new;
+        var activeConvId = isNewSession ? null : ((context && context.convId) || _convId);
 
         // Reuse existing conversation or create new one
         if (!activeConvId) {

--- a/electron/providers/claude-engine.js
+++ b/electron/providers/claude-engine.js
@@ -89,22 +89,26 @@
     }
 
     // ─── Send Message ───────────────────────────────
-    async function send(message) {
+    async function send(message, context) {
         var orgId = await _getOrgId();
 
+        // Determine which convId to use: provided context or global state
+        var activeConvId = (context && context.convId) || _convId;
+
         // Reuse existing conversation or create new one
-        if (!_convId) {
-            _convId = await _createConversation(orgId, message);
-            console.log('[Proxima Claude] Created new conversation:', _convId);
+        if (!activeConvId) {
+            activeConvId = await _createConversation(orgId, message);
+            _convId = activeConvId; // Also update global for backward compat
+            console.log('[Proxima Claude] Created new conversation:', activeConvId);
         } else {
-            console.log('[Proxima Claude] Continuing conversation:', _convId);
+            console.log('[Proxima Claude] Continuing conversation:', activeConvId);
         }
 
         try {
             var controller = new AbortController();
             var timeoutId = setTimeout(function() { controller.abort(); }, TIMEOUT);
 
-            var res = await fetch('/api/organizations/' + orgId + '/chat_conversations/' + _convId + '/completion', {
+            var res = await fetch('/api/organizations/' + orgId + '/chat_conversations/' + activeConvId + '/completion', {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
@@ -127,12 +131,13 @@
                 // Conversation expired or deleted — create new and retry
                 if (res.status === 404 || res.status === 410) {
                     console.log('[Proxima Claude] Conversation expired, creating new one...');
-                    _convId = await _createConversation(orgId, message);
+                    activeConvId = await _createConversation(orgId, message);
+                    _convId = activeConvId; // Update global state
 
                     var retryController = new AbortController();
                     var retryTimeoutId = setTimeout(function() { retryController.abort(); }, TIMEOUT);
 
-                    res = await fetch('/api/organizations/' + orgId + '/chat_conversations/' + _convId + '/completion', {
+                    res = await fetch('/api/organizations/' + orgId + '/chat_conversations/' + activeConvId + '/completion', {
                         method: 'POST',
                         credentials: 'include',
                         headers: {
@@ -155,7 +160,7 @@
 
                     var result = await _parseStream(res);
                     clearTimeout(retryTimeoutId);
-                    return result;
+                    return { text: result, context: { convId: activeConvId } };
                 }
 
                 if (res.status === 429) throw new Error('Claude rate limited');
@@ -164,7 +169,7 @@
 
             var result = await _parseStream(res);
             clearTimeout(timeoutId);
-            return result;
+            return { text: result, context: { convId: activeConvId } };
         } catch(e) {
             // Reset on conversation-related errors so next call creates fresh
             if (e.message && (e.message.includes('404') || e.message.includes('410'))) {

--- a/electron/providers/gemini-engine.js
+++ b/electron/providers/gemini-engine.js
@@ -192,7 +192,7 @@
 
     // ─── Send Message ───────────────────────────────
 
-    async function send(message) {
+    async function send(message, context) {
         var tokens = await _getTokens();
         var reqId = Math.floor(900000 * Math.random()) + 100000;
 
@@ -202,11 +202,14 @@
             _reqid: reqId.toString()
         });
 
+        var activeConversationId = (context && context.conversationId) || _conversationId;
+        var activeResponseId = (context && context.responseId) || _responseId;
+        var activeChoiceId = (context && context.choiceId) || _choiceId;
 
-        var conversationContext = [_conversationId, _responseId, _choiceId];
+        var conversationContext = [activeConversationId, activeResponseId, activeChoiceId];
         
-        if (_conversationId) {
-            console.log('[Proxima Gemini] Continuing conversation: ' + _conversationId.substring(0, 20) + '...');
+        if (activeConversationId) {
+            console.log('[Proxima Gemini] Continuing conversation: ' + activeConversationId.substring(0, 20) + '...');
         } else {
             console.log('[Proxima Gemini] Starting new conversation');
         }
@@ -272,7 +275,7 @@
 
             var result = _parseResponse(await res.text());
             clearTimeout(retryTimeoutId);
-            return result;
+            return { text: result, context: { conversationId: _conversationId, responseId: _responseId, choiceId: _choiceId } };
         }
 
         if (!res.ok) {
@@ -283,7 +286,7 @@
 
         var result = _parseResponse(await res.text());
         clearTimeout(timeoutId);
-        return result;
+        return { text: result, context: { conversationId: _conversationId, responseId: _responseId, choiceId: _choiceId } };
     }
 
 

--- a/electron/providers/gemini-engine.js
+++ b/electron/providers/gemini-engine.js
@@ -202,9 +202,11 @@
             _reqid: reqId.toString()
         });
 
-        var activeConversationId = (context && context.conversationId) || _conversationId;
-        var activeResponseId = (context && context.responseId) || _responseId;
-        var activeChoiceId = (context && context.choiceId) || _choiceId;
+        // context.__new means "start a new conversation, don't reuse global state"
+        var isNewSession = context && context.__new;
+        var activeConversationId = isNewSession ? '' : ((context && context.conversationId) || _conversationId);
+        var activeResponseId = isNewSession ? '' : ((context && context.responseId) || _responseId);
+        var activeChoiceId = isNewSession ? '' : ((context && context.choiceId) || _choiceId);
 
         var conversationContext = [activeConversationId, activeResponseId, activeChoiceId];
         

--- a/electron/providers/perplexity-engine.js
+++ b/electron/providers/perplexity-engine.js
@@ -152,7 +152,9 @@
     // ─── Send Message ───────────────────────────────
 
     async function send(message, context) {
-        var activeLastBackendUuid = (context && context.lastBackendUuid) || _lastBackendUuid;
+        // context.__new means "start a new conversation, don't reuse global state"
+        var isNewSession = context && context.__new;
+        var activeLastBackendUuid = isNewSession ? null : ((context && context.lastBackendUuid) || _lastBackendUuid);
         var sessionToken = _getSessionToken();
         var frontendUuid = _uuid();
 

--- a/electron/providers/perplexity-engine.js
+++ b/electron/providers/perplexity-engine.js
@@ -151,12 +151,13 @@
 
     // ─── Send Message ───────────────────────────────
 
-    async function send(message) {
+    async function send(message, context) {
+        var activeLastBackendUuid = (context && context.lastBackendUuid) || _lastBackendUuid;
         var sessionToken = _getSessionToken();
         var frontendUuid = _uuid();
 
         var params = {
-            last_backend_uuid: _lastBackendUuid || _uuid(),
+            last_backend_uuid: activeLastBackendUuid || _uuid(),
             read_write_token: sessionToken || '',
             attachments: [],
             language: navigator.language || 'en-US',
@@ -169,7 +170,7 @@
             is_related_query: false,
             is_sponsored: false,
             prompt_source: 'user',
-            query_source: _lastBackendUuid ? 'followup' : 'home',
+            query_source: activeLastBackendUuid ? 'followup' : 'home',
             is_incognito: false,
             time_from_first_type: Math.floor(Math.random() * 5000) + 1000,
             local_search_enabled: false,
@@ -238,7 +239,7 @@
             throw new Error('Perplexity returned empty response');
         }
 
-        return result;
+        return { text: result, context: { lastBackendUuid: _lastBackendUuid } };
     }
 
 

--- a/electron/rest-api.cjs
+++ b/electron/rest-api.cjs
@@ -4,6 +4,7 @@
 const http = require('http');
 const { URL } = require('url');
 const { initWebSocket, getWSStats } = require('./ws-server.cjs');
+const sessionStore = require('./session-store.cjs');
 
 // ─── Config ──────────────────────────────────────────────
 const REST_PORT = parseInt(process.env.PROXIMA_REST_PORT) || 3210;
@@ -1223,6 +1224,99 @@ End with a security score (0-100).`;
         }
 
         // ── No function = Normal Chat (default) ──
+        // Session-aware routing when messages array is present
+        if (body.messages && Array.isArray(body.messages) && body.messages.length > 0 && resolved.mode === 'single') {
+            const provider = resolved.providers[0];
+            const fingerprint = sessionStore.computeFingerprint(body.messages);
+            const existingSession = sessionStore.lookup(fingerprint, provider);
+
+            let messageToSend;
+            let sessionContext = null;
+
+            if (existingSession) {
+                // Existing session: send only last user message, no system prompt
+                messageToSend = sessionStore.extractLastUserMessage(body.messages);
+                sessionContext = existingSession;
+            } else {
+                // New session: prepend system prompt if present
+                messageToSend = sessionStore.composeNewSessionMessage(body.messages);
+            }
+
+            if (!messageToSend) return sendError(res, 400, 'No message provided. Use "messages" array or "message" field.');
+
+            try {
+                initProviderStats(provider);
+                const start = Date.now();
+
+                const sendResult = await handleMCPRequest({
+                    action: 'sendMessage', provider, data: { message: messageToSend, context: sessionContext }
+                });
+
+                if (!sendResult.success) throw new Error(sendResult.error || `Failed to send to ${provider}`);
+
+                let responseText = '';
+                let returnedContext = null;
+
+                if (sendResult.result && sendResult.result.response) {
+                    // Check if response is an object with text/context (new format)
+                    if (typeof sendResult.result.response === 'object' && sendResult.result.response.text !== undefined) {
+                        responseText = sendResult.result.response.text;
+                        returnedContext = sendResult.result.response.context || null;
+                    } else {
+                        responseText = sendResult.result.response;
+                    }
+                }
+
+                // If we got context back from the provider, store it
+                if (sendResult.result && sendResult.result.context) {
+                    returnedContext = sendResult.result.context;
+                }
+
+                if (returnedContext) {
+                    sessionStore.store(fingerprint, provider, returnedContext);
+                }
+
+                // Handle expired conversation (stale mapping)
+                if (!responseText && existingSession) {
+                    // Remove stale mapping and retry as new session
+                    sessionStore.remove(fingerprint, provider);
+                    const retryMessage = sessionStore.composeNewSessionMessage(body.messages);
+                    const retryResult = await handleMCPRequest({
+                        action: 'sendMessage', provider, data: { message: retryMessage, context: null }
+                    });
+                    if (!retryResult.success) throw new Error(retryResult.error || `Failed to send to ${provider}`);
+                    if (retryResult.result && retryResult.result.response) {
+                        if (typeof retryResult.result.response === 'object' && retryResult.result.response.text !== undefined) {
+                            responseText = retryResult.result.response.text;
+                            returnedContext = retryResult.result.response.context || null;
+                        } else {
+                            responseText = retryResult.result.response;
+                        }
+                    }
+                    if (retryResult.result && retryResult.result.context) {
+                        returnedContext = retryResult.result.context;
+                    }
+                    if (returnedContext) {
+                        sessionStore.store(fingerprint, provider, returnedContext);
+                    }
+                }
+
+                const elapsed = Date.now() - start;
+                recordCall(provider, elapsed);
+
+                sendJSON(res, 200, formatChatResponse({ text: responseText, model: provider, responseTimeMs: elapsed }, provider));
+            } catch (e) {
+                // If error indicates expired conversation (404/410), remove stale mapping
+                if (existingSession && (e.message.includes('404') || e.message.includes('410'))) {
+                    sessionStore.remove(fingerprint, provider);
+                }
+                recordCall(provider, 0, true);
+                sendError(res, 500, e.message);
+            }
+            return;
+        }
+
+        // Fallback: simple message format (no messages array) or multi-provider
         const message = extractMessage(body);
         if (!message) return sendError(res, 400, 'No message provided. Use "messages" array or "message" field.');
 

--- a/electron/rest-api.cjs
+++ b/electron/rest-api.cjs
@@ -1240,6 +1240,8 @@ End with a security score (0-100).`;
             } else {
                 // New session: prepend system prompt if present
                 messageToSend = sessionStore.composeNewSessionMessage(body.messages);
+                // Pass empty context to signal "start a new conversation" to the engine
+                sessionContext = { __new: true };
             }
 
             if (!messageToSend) return sendError(res, 400, 'No message provided. Use "messages" array or "message" field.');
@@ -1304,7 +1306,12 @@ End with a security score (0-100).`;
                 const elapsed = Date.now() - start;
                 recordCall(provider, elapsed);
 
-                sendJSON(res, 200, formatChatResponse({ text: responseText, model: provider, responseTimeMs: elapsed }, provider));
+                const sessionResult = { text: responseText, model: provider, responseTimeMs: elapsed };
+                if (body.stream) {
+                    sendSSE(res, sessionResult, provider);
+                } else {
+                    sendJSON(res, 200, formatChatResponse(sessionResult, provider));
+                }
             } catch (e) {
                 // If error indicates expired conversation (404/410), remove stale mapping
                 if (existingSession && (e.message.includes('404') || e.message.includes('410'))) {

--- a/electron/session-store.cjs
+++ b/electron/session-store.cjs
@@ -1,0 +1,256 @@
+/**
+ * Proxima — Session Store
+ * Maps session fingerprints to per-provider conversation state.
+ * Provides LRU eviction (max 1000 per provider) and TTL-based expiry (24h).
+ */
+
+const crypto = require('crypto');
+
+// ─── Constants ───────────────────────────────────────────
+const MAX_SIZE = 1000;
+const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ─── ProviderSessionMap ──────────────────────────────────
+
+class ProviderSessionMap {
+  constructor(maxSize = MAX_SIZE, ttlMs = TTL_MS) {
+    this.maxSize = maxSize;
+    this.ttlMs = ttlMs;
+    this.entries = new Map(); // fingerprint → { state, lastAccessed, createdAt }
+  }
+
+  /**
+   * Look up a session by fingerprint.
+   * Returns the conversation state or null.
+   * Updates lastAccessed on hit. Evicts expired entries lazily.
+   */
+  lookup(fingerprint) {
+    const entry = this.entries.get(fingerprint);
+    if (!entry) return null;
+
+    // TTL check — evict if expired
+    if (Date.now() - entry.lastAccessed > this.ttlMs) {
+      this.entries.delete(fingerprint);
+      return null;
+    }
+
+    // Update lastAccessed and move to end of Map (most recently used)
+    entry.lastAccessed = Date.now();
+    this.entries.delete(fingerprint);
+    this.entries.set(fingerprint, entry);
+
+    return entry.state;
+  }
+
+  /**
+   * Store a session mapping. Enforces max capacity with LRU eviction.
+   */
+  store(fingerprint, conversationState) {
+    // If key already exists, delete it first so re-insertion moves it to end
+    if (this.entries.has(fingerprint)) {
+      this.entries.delete(fingerprint);
+    } else if (this.entries.size >= this.maxSize) {
+      // Evict LRU entry (first entry in Map iteration order)
+      const lruKey = this.entries.keys().next().value;
+      this.entries.delete(lruKey);
+      console.warn(`[SessionStore] WARNING: Evicting LRU session for provider (at capacity: ${this.maxSize})`);
+    }
+
+    this.entries.set(fingerprint, {
+      state: conversationState,
+      lastAccessed: Date.now(),
+      createdAt: Date.now()
+    });
+  }
+
+  /**
+   * Remove a specific session mapping.
+   */
+  remove(fingerprint) {
+    return this.entries.delete(fingerprint);
+  }
+
+  /**
+   * Clear all sessions.
+   */
+  clear() {
+    this.entries.clear();
+  }
+
+  /**
+   * Get the number of active (non-expired) entries.
+   */
+  get size() {
+    return this.entries.size;
+  }
+}
+
+// ─── Top-level Store ─────────────────────────────────────
+
+const providers = {
+  chatgpt: new ProviderSessionMap(),
+  claude: new ProviderSessionMap(),
+  gemini: new ProviderSessionMap(),
+  perplexity: new ProviderSessionMap()
+};
+
+// ─── Content Normalization ───────────────────────────────
+
+/**
+ * Normalize message content to a plain string.
+ * Handles:
+ *   - string values (pass-through)
+ *   - OpenAI content-part arrays: [{ type: "text", text: "..." }, ...]
+ *   - Objects with a `text` field: { text: "..." }
+ */
+function normalizeContent(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    // OpenAI content-part array — concatenate text parts
+    return content
+      .filter(part => part && part.type === 'text' && typeof part.text === 'string')
+      .map(part => part.text)
+      .join('');
+  }
+
+  if (content && typeof content === 'object' && typeof content.text === 'string') {
+    return content.text;
+  }
+
+  return '';
+}
+
+// ─── Message Extraction ──────────────────────────────────
+
+/**
+ * Extract and normalize the content of the last user-role message.
+ */
+function extractLastUserMessage(messages) {
+  if (!messages || !Array.isArray(messages)) return '';
+  const userMsgs = messages.filter(m => m && m.role === 'user');
+  if (userMsgs.length === 0) return '';
+  return normalizeContent(userMsgs[userMsgs.length - 1].content);
+}
+
+/**
+ * Compose a message for a new session:
+ * Prepend the last system prompt (if any) to the last user message,
+ * separated by a double newline.
+ */
+function composeNewSessionMessage(messages) {
+  if (!messages || !Array.isArray(messages)) return '';
+
+  const lastUserMsg = extractLastUserMessage(messages);
+  const systemMsgs = messages.filter(m => m && m.role === 'system');
+
+  if (systemMsgs.length > 0) {
+    const systemContent = normalizeContent(systemMsgs[systemMsgs.length - 1].content);
+    if (systemContent) {
+      return systemContent + '\n\n' + lastUserMsg;
+    }
+  }
+
+  return lastUserMsg;
+}
+
+// ─── Fingerprint Computation ─────────────────────────────
+
+/**
+ * Compute a session fingerprint from a messages array.
+ * SHA-256 hash of the normalized first user-role message content.
+ * Returns crypto.randomUUID() for malformed/missing user messages.
+ */
+function computeFingerprint(messages) {
+  if (!messages || !Array.isArray(messages)) {
+    return crypto.randomUUID();
+  }
+
+  const firstUserMsg = messages.find(m => m && m.role === 'user');
+  if (!firstUserMsg) {
+    return crypto.randomUUID();
+  }
+
+  const normalized = normalizeContent(firstUserMsg.content);
+  if (!normalized) {
+    return crypto.randomUUID();
+  }
+
+  return crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
+}
+
+// ─── Public API ──────────────────────────────────────────
+
+/**
+ * Look up a session for a given fingerprint and provider.
+ * Returns conversation state or null.
+ */
+function lookup(fingerprint, provider) {
+  const map = providers[provider];
+  if (!map) return null;
+  return map.lookup(fingerprint);
+}
+
+/**
+ * Store a session mapping for a given fingerprint and provider.
+ */
+function store(fingerprint, provider, conversationState) {
+  const map = providers[provider];
+  if (!map) return;
+  map.store(fingerprint, conversationState);
+}
+
+/**
+ * Remove a specific session mapping.
+ */
+function remove(fingerprint, provider) {
+  const map = providers[provider];
+  if (!map) return false;
+  return map.remove(fingerprint);
+}
+
+/**
+ * Clear all sessions for a provider (used by newConversation reset).
+ */
+function clearProvider(provider) {
+  const map = providers[provider];
+  if (!map) return;
+  map.clear();
+}
+
+/**
+ * Get session statistics.
+ */
+function getStats() {
+  const providerStats = {};
+  let totalCount = 0;
+
+  for (const [name, map] of Object.entries(providers)) {
+    providerStats[name] = map.size;
+    totalCount += map.size;
+  }
+
+  return {
+    sessionCount: totalCount,
+    providers: providerStats
+  };
+}
+
+// ─── Exports ─────────────────────────────────────────────
+
+module.exports = {
+  computeFingerprint,
+  lookup,
+  store,
+  remove,
+  clearProvider,
+  getStats,
+  // Utilities exported for use by rest-api.cjs and tests
+  normalizeContent,
+  extractLastUserMessage,
+  composeNewSessionMessage,
+  // Expose class for testing with custom parameters
+  ProviderSessionMap
+};


### PR DESCRIPTION
## Session-Aware Conversation Routing

Enables multiple independent conversations per provider simultaneously. Instead of a single global conversation, Proxima now computes a fingerprint from the first user message in each request's `messages` array and routes follow-up messages to the correct provider conversation.

### What it does

- Computes a SHA-256 fingerprint from the first user-role message to identify sessions
- Maps fingerprints to per-provider conversation state (conversation IDs, parent message IDs, etc.)
- Routes follow-up messages to the correct existing conversation
- Starts new provider conversations when a new fingerprint is seen
- Prepends system prompt to the first message of new sessions, omits it on follow-ups
- Handles expired/deleted conversations (404/410) by removing stale mappings and retrying
- Supports SSE streaming responses in the session-aware path
- LRU eviction (max 1000 sessions per provider) with 24-hour TTL

### Changes

- New `electron/session-store.cjs` — fingerprint computation, per-provider LRU session maps, message composition utilities
- Modified all 4 engine `send()` functions to accept/return `{ text, context }` objects
- Modified `provider-api.cjs` to pass context through, clear session store on reset
- Modified `main-v2.cjs` to thread context through `sendMessageToProvider`
- Modified `rest-api.cjs` with session-aware routing in the chat completions handler

### Backward compatible

All changes are backward-compatible. When no `messages` array is present (simple `message` field), or when using multi-provider mode, the existing non-session path is used. Engines without context parameters behave as before.

### Testing note

This has been tested with ChatGPT only. The engine interface changes are implemented for all four providers (Claude, Gemini, Perplexity) but have not been validated end-to-end on those providers yet.
